### PR TITLE
pkg/v1/client: support new cluster audience in pacific

### DIFF
--- a/cmd/cli/plugin/cluster/kubeconfig_get.go
+++ b/cmd/cli/plugin/cluster/kubeconfig_get.go
@@ -96,8 +96,11 @@ func getPinnipedKubeconfig(tkgctlClient tkgctl.TKGClient, workloadClusterName st
 		return err
 	}
 
-	// for workload cluster the audience would be set to the clustername
+	// For (legacy) workload clusters, the audience is just <cluster-name>
 	audience := clusterPinnipedInfo.ClusterName
+	if clusterPinnipedInfo.ClusterAudience != nil {
+		audience = *clusterPinnipedInfo.ClusterAudience
+	}
 
 	kubeconfig, err := tkgauth.GetPinnipedKubeconfig(clusterPinnipedInfo.ClusterInfo, clusterPinnipedInfo.PinnipedInfo,
 		clusterPinnipedInfo.ClusterName, audience)

--- a/pkg/v1/tkg/client/get_cluster_pinniped_info_test.go
+++ b/pkg/v1/tkg/client/get_cluster_pinniped_info_test.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -57,6 +58,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 		conciergeIsClusterScopedWLCluster bool
 		servCert                          *x509.Certificate
 		clusterPinnipedInfo               *ClusterPinnipedInfo
+		isPacific                         bool
 	)
 
 	var (
@@ -126,7 +128,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 			BeforeEach(func() {
 				// create a fake controller-runtime cluster with the []runtime.Object mentioned with createClusterOptions
 				fakeClientSet = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(
-					createFakeClusterRefObjects(mgmtClusterName, searchNamespace, endpoint, "invalid kubeconfig")...).Build()
+					createFakeClusterRefObjects(mgmtClusterName, searchNamespace, "some-uid", endpoint, "invalid kubeconfig")...).Build()
 			})
 			It("should return an error", func() {
 				Expect(err).To(HaveOccurred())
@@ -137,7 +139,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 			BeforeEach(func() {
 				// create a fake controller-runtime cluster with the []runtime.Object mentioned with createClusterOptions
 				fakeClientSet = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(
-					createFakeClusterRefObjects(mgmtClusterName, searchNamespace, endpoint, readFile(kubeconfig))...).Build()
+					createFakeClusterRefObjects(mgmtClusterName, searchNamespace, "some-uid", endpoint, readFile(kubeconfig))...).Build()
 				tlsServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
@@ -165,7 +167,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 				})
 				// create a fake controller-runtime cluster with the []runtime.Object mentioned with createClusterOptions
 				fakeClientSet = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(
-					createFakeClusterRefObjects(mgmtClusterName, searchNamespace, endpoint, readFile(kubeconfig))...).Build()
+					createFakeClusterRefObjects(mgmtClusterName, searchNamespace, "some-uid", endpoint, readFile(kubeconfig))...).Build()
 				tlsServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
@@ -176,6 +178,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 			It("should return the cluster pinniped information successfully", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(clusterPinnipedInfo.ClusterName).To(Equal(mgmtClusterName))
+				Expect(clusterPinnipedInfo.ClusterAudience).To(BeNil())
 				Expect(clusterPinnipedInfo.ClusterInfo.Server).To(Equal(endpoint))
 				Expect(clusterPinnipedInfo.PinnipedInfo.Data.Issuer).To(Equal(issuer))
 				Expect(clusterPinnipedInfo.PinnipedInfo.Data.IssuerCABundle).To(Equal(issuerCA))
@@ -200,7 +203,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 				Namespace:           constants.DefaultNamespace,
 				IsManagementCluster: false,
 			}
-			clusterPinnipedInfo, err = tkgClient.GetWCClusterPinnipedInfo(regionalClusterClient, region, options)
+			clusterPinnipedInfo, err = tkgClient.GetWCClusterPinnipedInfo(regionalClusterClient, region, options, isPacific)
 		})
 
 		Context("When workload cluster is not found", func() {
@@ -218,7 +221,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 				searchNamespace = constants.DefaultNamespace
 				// create a fake controller-runtime cluster with the []runtime.Object mentioned with createClusterOptions
 				fakeClientSet = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(
-					createFakeClusterRefObjects("fake-workload-cluster", searchNamespace, endpoint, "invalid kubeconfig")...).Build()
+					createFakeClusterRefObjects("fake-workload-cluster", searchNamespace, "some-uid", endpoint, "invalid kubeconfig")...).Build()
 			})
 			It("should return an error", func() {
 				Expect(err).To(HaveOccurred())
@@ -229,8 +232,8 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 		Context("When management cluster pinniped-info configmap is not present in kube-public namespace", func() {
 			BeforeEach(func() {
 				var clusterRefs []runtime.Object
-				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", wlClusterEndpoint, readFile(wlKubeconfig))...)
-				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, searchNamespace, endpoint, readFile(kubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", "some-uid", wlClusterEndpoint, readFile(wlKubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, "some-uid", searchNamespace, endpoint, readFile(kubeconfig))...)
 				searchNamespace = constants.DefaultNamespace
 				// create a fake controller-runtime cluster with the []runtime.Object mentioned with createClusterOptions
 				fakeClientSet = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(clusterRefs...).Build()
@@ -250,8 +253,8 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 		Context("When WL cluster pinniped-info configmap is not present in kube-public namespace", func() {
 			BeforeEach(func() {
 				var clusterRefs []runtime.Object
-				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", wlClusterEndpoint, readFile(wlKubeconfig))...)
-				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, searchNamespace, endpoint, readFile(kubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", "some-uid", wlClusterEndpoint, readFile(wlKubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, searchNamespace, "some-uid", endpoint, readFile(kubeconfig))...)
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
 				conciergeIsClusterScoped = false
@@ -280,6 +283,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 			It("should not return an error and utilize management cluster pinniped info", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(clusterPinnipedInfo.ClusterName).To(Equal(wlClusterName))
+				Expect(clusterPinnipedInfo.ClusterAudience).To(BeNil())
 				Expect(clusterPinnipedInfo.ClusterInfo.Server).To(Equal(wlClusterEndpoint))
 				Expect(clusterPinnipedInfo.PinnipedInfo.Data.Issuer).To(Equal(issuer))
 				Expect(clusterPinnipedInfo.PinnipedInfo.Data.IssuerCABundle).To(Equal(issuerCA))
@@ -291,8 +295,8 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 		Context("When WL cluster pinniped-info configmap is present and malformed in kube-public namespace", func() {
 			BeforeEach(func() {
 				var clusterRefs []runtime.Object
-				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", wlClusterEndpoint, readFile(wlKubeconfig))...)
-				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, searchNamespace, endpoint, readFile(kubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", "some-uid", wlClusterEndpoint, readFile(wlKubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, searchNamespace, "some-uid", endpoint, readFile(kubeconfig))...)
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
 				conciergeIsClusterScoped = false
@@ -323,8 +327,8 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 		Context("When cluster-info and pinniped-info configmap are present in kube-public namespace", func() {
 			BeforeEach(func() {
 				var clusterRefs []runtime.Object
-				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", wlClusterEndpoint, readFile(wlKubeconfig))...)
-				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, searchNamespace, endpoint, readFile(kubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", "some-uid", wlClusterEndpoint, readFile(wlKubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, searchNamespace, "some-uid", endpoint, readFile(kubeconfig))...)
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
 				conciergeIsClusterScoped = false
@@ -354,6 +358,54 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 			It("should return the cluster pinniped information successfully", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(clusterPinnipedInfo.ClusterName).To(Equal(wlClusterName))
+				Expect(clusterPinnipedInfo.ClusterAudience).To(BeNil())
+				Expect(clusterPinnipedInfo.ClusterInfo.Server).To(Equal(wlClusterEndpoint))
+				Expect(clusterPinnipedInfo.PinnipedInfo.Data.Issuer).To(Equal(issuer))
+				Expect(clusterPinnipedInfo.PinnipedInfo.Data.IssuerCABundle).To(Equal(issuerCA))
+				Expect(clusterPinnipedInfo.PinnipedInfo.Data.ConciergeIsClusterScoped).To(Equal(conciergeIsClusterScopedWLCluster))
+			})
+		})
+
+		Context("When we are talking to a pacific cluster", func() {
+			const wlClusterUID = "some-pacific-cluster-uid"
+
+			BeforeEach(func() {
+				isPacific = true
+
+				var clusterRefs []runtime.Object
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", wlClusterUID, wlClusterEndpoint, readFile(wlKubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, searchNamespace, "some-uid", endpoint, readFile(kubeconfig))...)
+				issuer = fakeIssuer
+				issuerCA = fakeCAData
+				conciergeIsClusterScoped = false
+				conciergeIsClusterScopedWLCluster = true
+				pinnipedInfoCM := fakehelper.PinnipedInfo{
+					ClusterName:              mgmtClusterName,
+					Issuer:                   issuer,
+					IssuerCABundleData:       issuerCA,
+					ConciergeIsClusterScoped: conciergeIsClusterScoped,
+				}
+				clusterRefs = append(clusterRefs, getPinnipedInfoConfigMapObjectFromPinnipedInfo(pinnipedInfoCM))
+
+				pinnipedInfoWorkloadCluster := fakehelper.GetFakePinnipedInfo(fakehelper.PinnipedInfo{
+					ConciergeIsClusterScoped: conciergeIsClusterScopedWLCluster,
+				})
+				searchNamespace = constants.DefaultNamespace
+				// create a fake controller-runtime cluster with the []runtime.Object mentioned with createClusterOptions
+				fakeClientSet = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(clusterRefs...).Build()
+
+				tlsServerWLCluster.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
+						ghttp.RespondWith(http.StatusOK, pinnipedInfoWorkloadCluster),
+					),
+				)
+			})
+			It("should return the cluster pinniped information successfully with a special audience", func() {
+				wantClusterAudience := fmt.Sprintf("%s-%s", wlClusterName, wlClusterUID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(clusterPinnipedInfo.ClusterName).To(Equal(wlClusterName))
+				Expect(clusterPinnipedInfo.ClusterAudience).To(Equal(&wantClusterAudience))
 				Expect(clusterPinnipedInfo.ClusterInfo.Server).To(Equal(wlClusterEndpoint))
 				Expect(clusterPinnipedInfo.PinnipedInfo.Data.Issuer).To(Equal(issuer))
 				Expect(clusterPinnipedInfo.PinnipedInfo.Data.IssuerCABundle).To(Equal(issuerCA))
@@ -384,7 +436,7 @@ func getFakeKubeConfigFilePathWithServer(testingDir, endpoint, clustername strin
 }
 
 // TODO: Should be merged to pkg/fakes/helpers/fakeobjectcreator.go
-func createFakeClusterRefObjects(name, namespace, endpoint, kubeconfig string) []runtime.Object {
+func createFakeClusterRefObjects(name, namespace, uid, endpoint, kubeconfig string) []runtime.Object {
 	u, _ := url.Parse(endpoint)
 	host, port, _ := net.SplitHostPort(u.Host)
 	portInt32, _ := strconv.ParseInt(port, 10, 32)
@@ -398,6 +450,7 @@ func createFakeClusterRefObjects(name, namespace, endpoint, kubeconfig string) [
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			UID:       types.UID(uid),
 		},
 
 		Spec: capi.ClusterSpec{


### PR DESCRIPTION
### What this PR does / why we need it

```
	// For clusters that use a TKr API version newer than v1alpha1, we use the cluster name + UID as
	// the audience
	//
	// For right now, only do this on pacific clusters to limit the blast radius of the change; in the
	// future, we will want to do this for all clusters
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

None

### Describe testing done for PR

* Ran `make build-install-cli-local` and made sure i could generate and use kubeconfigs against 1.21.x, 1.22.x, and 1.23.x TKr's

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

None

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->

None